### PR TITLE
Fixes bug where img elements without the realSrcAttribute disappear in Firefox

### DIFF
--- a/Source/LazyLoad.js
+++ b/Source/LazyLoad.js
@@ -104,15 +104,19 @@ var LazyLoad = new Class({
 		this.container.addEvent("scroll", action);
 	},
 	loadImage: function(image) {
-		// Set load event for fadeIn
-		if(this.options.useFade) {
-			image.addEvent("load", function(){
-				image.fade(1);
-			});
+		var realSrc = image.get(this.options.realSrcAttribute);
+		
+		if (realSrc !== null) {		
+			// Set load event for fadeIn
+			if(this.options.useFade) {
+				image.addEvent("load", function(){
+					image.fade(1);
+				});
+			}
+			
+			image.set("src", realSrc);
+			// Fire the image load event
+			this.fireEvent("load", [image]);
 		}
-		// Set the SRC
-		image.set("src", image.get(this.options.realSrcAttribute));
-		// Fire the image load event
-		this.fireEvent("load", [image]);
 	}
 });


### PR DESCRIPTION
Fixes bug where img elements without the realSrcAttribute disappear in Firefox.

Original code attempts to replace the src of all img regardless of whether there is any realSrcAttribute. This means that user cannot create a page where certain images are lazily loaded while others are not.
