### PR TITLE
Added listener on javascript error to show all images

### DIFF
--- a/Source/onerror.js
+++ b/Source/onerror.js
@@ -1,0 +1,34 @@
+/*Adding onerror listener to show all images, if an error will occur*/
+window.onerror = function() {
+
+	window.onload = function() {
+
+		/*Getting all images*/
+		var images = document.getElementsByTagName('img');
+
+		if(images.length > 0) {
+
+			var src = null;
+
+			for( var i = 0; i <= images.length; i++ ) {
+
+				if( typeof images[i] != 'undefined' ) {
+
+					src = images[i].getAttribute('data_src');
+
+					/*If specified real src in image, change it*/
+					if( src ) {
+
+						images[i].src = src;
+
+					}
+
+				}
+
+			}
+
+		}
+
+	}
+
+}


### PR DESCRIPTION
Hi, I'm added listener on error to prevent situation when images are hidden.

To use it, just include file onerror.js. Better if it will be include before all scripts. For example in my project all scripts are combined in one file, and if some error will occure, images will be hidden.
Sometimes happens that loaded scripts are broken or something else so we don't have mootools features, this is the reason why I'm wrote this script in native code.

Hope it will be usefull.
