### PR TITLE
Only select elements with data-src attribute set

### DIFF
--- a/Source/LazyLoad.js
+++ b/Source/LazyLoad.js
@@ -22,7 +22,7 @@ var LazyLoad = new Class({
 	/* additional options */
 	options: {
 		range: 200,
-		elements: "img",
+		elements: "img[data-src]",
 		container: window,
 		mode: "vertical",
 		realSrcAttribute: "data-src",


### PR DESCRIPTION
If the default is to require images to have a data-src attribute set then the default selector should be images with said attribute set.
